### PR TITLE
Merge Request: dev_branch: bug fix for plain field (issue #4)

### DIFF
--- a/DbAutoFillAttribute.cs
+++ b/DbAutoFillAttribute.cs
@@ -22,6 +22,11 @@ namespace DatabaseAutoFill
         public string ParameterPrefix { get; set; }
 
         /// <summary>
+        /// When in FillMode
+        /// </summary>
+        public string ParameterSuffix { get; set; }
+
+        /// <summary>
         /// Allow specifying the DbType for the current property or field (e.g. DateTime2 instead of DateTime).
         /// </summary>
         public DbType DbType { get; set; }

--- a/DbAutoFillHelper.cs
+++ b/DbAutoFillHelper.cs
@@ -291,17 +291,28 @@ namespace DatabaseAutoFill
         /// <summary>
         /// 
         /// </summary>
-        private static void AddParameterFromAttribute<T>(IDbCommand cmd, T model, string modelParameterPrefix, string modelParameterSuffix, string propertyName, DbAutoFillAttribute propertyAttribute)
+        private static void AddParameterFromAttribute<T>(IDbCommand cmd, T model, string modelParameterPrefix, string modelParameterSuffix, string memberName, DbAutoFillAttribute propertyAttribute)
         {
-            string parameterName = modelParameterPrefix + propertyName + modelParameterSuffix;
+            string parameterName = modelParameterPrefix + memberName + modelParameterSuffix;
             DbType? sqlType = null;
 
-            if (!ParseAttributeInfosForParameter(propertyAttribute, modelParameterPrefix, modelParameterSuffix, propertyName, ref parameterName, ref sqlType))
+            if (!ParseAttributeInfosForParameter(propertyAttribute, modelParameterPrefix, modelParameterSuffix, memberName, ref parameterName, ref sqlType))
                 return;
 
-            object parameterValue = model.GetType()
-                .GetProperty(propertyName)
-                .GetValue(model, null);
+            object parameterValue = null;
+            Type modelType = model.GetType();
+            {
+                PropertyInfo pi = modelType.GetProperty(memberName);
+                if (pi == null)
+                {
+                    FieldInfo fi = modelType.GetField(memberName);
+                    parameterValue = fi.GetValue(model);
+                }
+                else
+                {
+                    parameterValue = pi.GetValue(model, null);
+                }
+            }
 
             AddParameterWithValue(cmd, parameterName, parameterValue, sqlType);
         }

--- a/test_DatabaseAutoFill/DbAutoFillTests.cs
+++ b/test_DatabaseAutoFill/DbAutoFillTests.cs
@@ -46,6 +46,8 @@ namespace test_DatabaseAutoFill
         private static readonly DateTime ADVANCED_DATAREADER_DBTYPEDEFAULT_VALUE = DateTime.Parse("2017/05/05 5:00 AM");
         private static readonly DateTime ADVANCED_DATAREADER_DBTYPE_VALUE = DateTime.Parse("2016/12/12 6:00 PM");
         private const string ADVANCED_DATAREADER_PREFIX_VALUE = "Hey, Sexy Lib!";
+
+        private const string ADVANCED_PARAMETER_SUFFIX_PARAM_NAME = "@p_WithSuffix_IN";
         #endregion
 
         #region --OBJECTS--
@@ -93,6 +95,15 @@ namespace test_DatabaseAutoFill
 
             [DbAutoFill(DbType = DbType.DateTime)]
             public DateTime DbTypeParameterDefault { get; set; }
+
+            [DbAutoFill(ParameterSuffix = "_IN", FillBehavior = FillBehavior.ToDB)]
+            public int WithSuffix { get; set; }
+        }
+
+        [DbAutoFill(ParameterPrefix = "@p_", ParameterSuffix = "_IN")]
+        public class ClassWithSuffix
+        {
+            public int WithSuffix { get; set; }
         }
 
         #endregion
@@ -156,6 +167,24 @@ namespace test_DatabaseAutoFill
         }
 
         [TestMethod]
+        public void Advanced_SetParametersFromObject_ParametersSuffix_OnProperty_Test()
+        {
+            AdvancedAutoFillClass aafc = new AdvancedAutoFillClass();
+            DbAutoFillHelper.AddParametersFromObjectMembers(_command, aafc);
+
+            Assert.IsTrue(_command.Parameters.Contains(ADVANCED_PARAMETER_SUFFIX_PARAM_NAME));
+        }
+
+        [TestMethod]
+        public void Advanced_SetParametersFromObject_ParametersSuffix_OnClass_Test()
+        {
+            ClassWithSuffix cws = new ClassWithSuffix();
+            DbAutoFillHelper.AddParametersFromObjectMembers(_command, cws);
+
+            Assert.IsTrue(_command.Parameters.Contains(ADVANCED_PARAMETER_SUFFIX_PARAM_NAME));
+        }
+
+        [TestMethod]
         [TestCategory("DatabaseAutoFill")]
         public void Advanced_GetParametersFromDataReader_GoodValues_Test()
         {
@@ -200,7 +229,7 @@ namespace test_DatabaseAutoFill
         public void FillObjectFromDataReader_GoodValues_Test()
         {
             _dvco = new DefaultValuesClassObject();
-            
+
             DbAutoFillHelper.FillObjectFromDataReader(_dvco, _dataReader);
 
             Assert.AreEqual(_dvco.Parameter1, DATAREADER_PARAMETER_1_VALUE);
@@ -208,7 +237,7 @@ namespace test_DatabaseAutoFill
             Assert.AreEqual(_dvco.FromDBParameter, DATAREADER_FROMDBPARAMETER_VALUE);
             Assert.AreNotEqual(_dvco.NoneParameter, DATAREADER_NONEPARAMETER_VALUE);
             Assert.AreNotEqual(_dvco.ToDBParameter, DATAREADER_ToDBPARAMETER_VALUE);
-            
+
         }
 
         private DataTable CreateNewDataTable()
@@ -238,7 +267,7 @@ namespace test_DatabaseAutoFill
         private IDataReader CreateAdvancedDataReader()
         {
             DataTable dt = CreateAdvancedDataTable();
-            dt.Rows.Add(ADVANCED_DATAREADER_ALIASED_VALUE, 
+            dt.Rows.Add(ADVANCED_DATAREADER_ALIASED_VALUE,
                 ADVANCED_DATAREADER_DBTYPEDEFAULT_VALUE,
                 ADVANCED_DATAREADER_DBTYPE_VALUE,
                 ADVANCED_DATAREADER_PREFIX_VALUE);

--- a/test_DatabaseAutoFill/DbAutoFillTests.cs
+++ b/test_DatabaseAutoFill/DbAutoFillTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Data;
 using System.Data.SqlClient;
+using test_DatabaseAutoFill.Objects;
 
 namespace test_DatabaseAutoFill
 {
@@ -32,6 +33,9 @@ namespace test_DatabaseAutoFill
         private const int DATAREADER_ToDBPARAMETER_VALUE = 11200;
         private const int DATAREADER_FROMDBPARAMETER_VALUE = 5645300;
 
+        private const string BASIC_PARAMETER_SECOND_OBJECT_NORMAL_FIELD = "NormalField";
+        private const int BASIC_PARAMETER_SECOND_OBJECT_NORMAL_FIELD_VALUE = 34;
+
         private const string ADVANCED_PARAMETER_PREFIX_OVERRIDE_PARAM_NAME = "@param_ParameterPrefixOverride";
         private const string ADVANCED_PARAMETER_PREFIX_OVERRIDE_NAME = "ParameterPrefixOverride";
         private const string ADVANCED_PARAMETER_ALLOWED_MISSING_PARAM_NAME = "@p_ParameterAllowedMissing";
@@ -51,6 +55,12 @@ namespace test_DatabaseAutoFill
         #endregion
 
         #region --OBJECTS--
+        [DbAutoFill]
+        public class SecondObject
+        {
+            public int NormalField = 34;
+        }
+
         [DbAutoFill]
         public class DefaultValuesClassObject
         {
@@ -173,6 +183,16 @@ namespace test_DatabaseAutoFill
             DbAutoFillHelper.AddParametersFromObjectMembers(_command, aafc);
 
             Assert.IsTrue(_command.Parameters.Contains(ADVANCED_PARAMETER_SUFFIX_PARAM_NAME));
+        }
+
+        [TestMethod]
+        public void Basic_SetParametersFromObject_PlainField_Test()
+        {
+            SecondObject so = new SecondObject();
+            DbAutoFillHelper.AddParametersFromObjectMembers(_command, so);
+
+            Assert.IsTrue(_command.Parameters.Contains(BASIC_PARAMETER_SECOND_OBJECT_NORMAL_FIELD));
+            Assert.IsTrue(_command.Parameters[BASIC_PARAMETER_SECOND_OBJECT_NORMAL_FIELD].Value.Equals(BASIC_PARAMETER_SECOND_OBJECT_NORMAL_FIELD_VALUE));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fix proposal for a bug where plain fields (e.g. not properties) were raising exceptions instead of getting added to the parameters in the DbCommand. See issue #4 for more details.

